### PR TITLE
updated mysql server listening check to use dockerl inks and port

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-while ! timeout 1 bash -c 'cat < /dev/null > /dev/tcp/db/8181'; do sleep 0.1; done
+while ! timeout 1 bash -c 'cat < /dev/null > /dev/tcp/mysql/3306'; do sleep 0.1; done
 
 apache2 -DFOREGROUND
 


### PR DESCRIPTION
I updated mysql wait bash script so it works now. However, I think the oc install directory is not part of the Dockerfile right now. So after mysql server is up, if [-d install] portion of the bash does not trigger.
